### PR TITLE
Implement logic to Update username.

### DIFF
--- a/onchain/src/systems/player_actions.cairo
+++ b/onchain/src/systems/player_actions.cairo
@@ -5,6 +5,7 @@ use starkludo::models::{player::{Player, PlayerTrait}};
 trait IPlayerActions {
     fn create(ref world: IWorldDispatcher, username: felt252);
     fn get_address_from_username(ref world: IWorldDispatcher, username: felt252) -> ContractAddress;
+    fn update_username(ref world: IWorldDispatcher, new_username: felt252);
 }
 
 #[dojo::contract]
@@ -36,6 +37,22 @@ mod PlayerActions {
             assert(player.owner != 0.try_into().unwrap(), 'player with username not found');
 
             player.owner
+        }
+
+        fn update_username(ref world: IWorldDispatcher, new_username: felt252) {
+            let caller = get_caller_address();
+            let mut player: Player = get!(world, caller, (Player));
+
+            // Only allow the player to update their own username
+            assert(player.owner == caller, 'only user can udpate username');
+
+            // Check if the new username is already taken
+            let mut existing_player = get!(world, new_username, (Player));
+            assert(existing_player.owner == 0.try_into().unwrap(), 'username already exist');
+
+            // Update the player's username
+            player.username = new_username;
+            set!(world, ( player));
         }
     }
 }

--- a/onchain/src/systems/player_actions.cairo
+++ b/onchain/src/systems/player_actions.cairo
@@ -5,7 +5,7 @@ use starkludo::models::{player::{Player, PlayerTrait}};
 trait IPlayerActions {
     fn create(ref world: IWorldDispatcher, username: felt252);
     fn get_address_from_username(ref world: IWorldDispatcher, username: felt252) -> ContractAddress;
-    fn update_username(ref world: IWorldDispatcher, new_username: felt252);
+    fn update_username(ref world: IWorldDispatcher, new_username: felt252, old_username: felt252);
 }
 
 #[dojo::contract]
@@ -39,9 +39,11 @@ mod PlayerActions {
             player.owner
         }
 
-        fn update_username(ref world: IWorldDispatcher, new_username: felt252) {
+        fn update_username(
+            ref world: IWorldDispatcher, new_username: felt252, old_username: felt252
+        ) {
             let caller = get_caller_address();
-            let mut player: Player = get!(world, caller, (Player));
+            let mut player: Player = get!(world, old_username, (Player));
 
             // Only allow the player to update their own username
             assert(player.owner == caller, 'only user can udpate username');
@@ -52,7 +54,7 @@ mod PlayerActions {
 
             // Update the player's username
             player.username = new_username;
-            set!(world, ( player));
+            set!(world, (player));
         }
     }
 }

--- a/onchain/src/tests/test_player.cairo
+++ b/onchain/src/tests/test_player.cairo
@@ -58,10 +58,36 @@ mod tests {
         testing::set_account_contract_address(caller);
         testing::set_contract_address(caller);
 
-        let (player_actions, world, _) = create_and_setup_player(username);
+        let (player_actions, _world, _) = create_and_setup_player(username);
 
         let princeibs_address = player_actions.get_address_from_username(username);
 
         assert_eq!(princeibs_address, caller);
+    }
+
+    #[test]
+    fn test_update_username() {
+        // Get the caller
+        let caller = contract_address_const::<'nuelo_address'>();
+        let old_username = 'neulo';
+        let new_username = 'new_nuelo';
+
+        testing::set_account_contract_address(caller);
+        testing::set_contract_address(caller);
+
+        let (player_actions, world, _) = create_and_setup_player(old_username);
+
+        // Update the player owner
+        let mut player = get!(world, caller, (Player));
+        player.owner = caller.try_into().unwrap();
+        set!(world, (player));
+
+        // Update username
+        player_actions.update_username(new_username);
+
+        // Verify the update
+        let mut player = get!(world, new_username, Player);
+        assert_eq!(player.owner, caller);
+        assert_eq!(player.username, new_username);
     }
 }

--- a/onchain/src/tests/test_player.cairo
+++ b/onchain/src/tests/test_player.cairo
@@ -65,6 +65,7 @@ mod tests {
         assert_eq!(princeibs_address, caller);
     }
 
+    
     #[test]
     fn test_update_username() {
         // Get the caller
@@ -78,16 +79,17 @@ mod tests {
         let (player_actions, world, _) = create_and_setup_player(old_username);
 
         // Update the player owner
-        let mut player = get!(world, caller, (Player));
-        player.owner = caller.try_into().unwrap();
-        set!(world, (player));
+        let mut player: Player = get!(world, old_username, Player);
+
+        assert_eq!(player.username, old_username);
 
         // Update username
-        player_actions.update_username(new_username);
+        player_actions.update_username(new_username, old_username);
 
-        // Verify the update
-        let mut player = get!(world, new_username, Player);
-        assert_eq!(player.owner, caller);
-        assert_eq!(player.username, new_username);
+        set!(world, (player));
+
+        let new_player: Player = get!(world, new_username, Player);
+
+        assert_eq!(new_player.username, new_username);
     }
 }


### PR DESCRIPTION
Closes #42 

### Description
Implement the logic to update username. This function contains the following checks.

- [x] only a player can update their username
- [x] They can only update to a username that has not been claimed by another player
- [x] uint test to verify logic correctness

### Files Updated:
- `onchain/src/systems/player_actions.cairo`
- `onchain/src/test/test_player.cairo`