### PR TITLE
feat:fixed pieces

### DIFF
--- a/client/src/styles/ControlWindowLayout.scss
+++ b/client/src/styles/ControlWindowLayout.scss
@@ -2,12 +2,13 @@
     height: 500px;
     width: 400px;
     color: white;
-    background-color: black;
+    background: black;
     position: absolute;
     top: 0;
     right: 0;
     display: flex;
     flex-direction: column;
+    z-index: 20;
 
     .handle {
         width: 100%;
@@ -16,47 +17,40 @@
 
         .close {
             cursor: pointer;
+            margin: 5px 0 0 7px;
             width: fit-content;
-            margin-left: 7px;
-            margin-top: 5px;
         }
     }
 
     .body {
-        overflow: scroll;
+        overflow-y: scroll;
         white-space: pre-wrap;
         scrollbar-width: none;
     }
 
     .heading {
-        width: 100%;
         display: flex;
         flex-direction: column;
-        color: white;
         text-align: center;
 
         .main {
-            color: white;
             font-size: 30px;
             font-family: "Rowdies", sans-serif;
             font-weight: 400;
-            font-style: normal;
         }
 
         .sub {
-            font-weight: 200;
             font-size: smaller;
+            font-weight: 200;
         }
     }
 
     .body-section {
         display: flex;
-        text-align: center;
         justify-content: center;
-        width: 100%;
+        text-align: center;
         padding: 0 20px;
+        width: 100%;
     }
-
 }
 
-// 


### PR DESCRIPTION
resolves issue: #22 
I ensured that when windows are moved over the board, they are display above the Ludo pieces rather than below them. 
