### PR TITLE
fix: prevent dice roll after player reaches home

### DIFF
--- a/client/src/components/Dice.tsx
+++ b/client/src/components/Dice.tsx
@@ -84,7 +84,7 @@ const Dice = () => {
       options.gameIsOngoing &&
       !options.winners.includes(options.playerChance)
     ) {
-      setGameOptions({ hasThrownDice: true, });
+      setGameOptions({ hasThrownDice: true, winners: [] });
       await rollDie(randomRollAmount());
     }
   };
@@ -98,7 +98,7 @@ const Dice = () => {
           </Col>
             <Col xs={6}>
               <div style={{
-              visibility: options.hasThrownDice ? "hidden":"visible"
+              visibility: (options.hasThrownDice || options.winners.includes(options.playerChance)) ? "hidden":"visible"
               }}>
               <div onClick={roller} className="button-container">
                 {options.gameIsOngoing && (<a className="start-over" onClick={(e) => {

--- a/client/src/components/Dice.tsx
+++ b/client/src/components/Dice.tsx
@@ -55,7 +55,6 @@ const Dice = () => {
 
   // The is the argument for the rollDie function
   const randomRollAmount = () => {
-
     return Math.floor(Math.random() * 30 + 15);
   };
 
@@ -104,8 +103,12 @@ const Dice = () => {
   };
 
   const roller = async () => {
-    if (!options.hasThrownDice) {
-      setGameOptions({ hasThrownDice: true });
+    if (
+      !options.hasThrownDice &&
+      options.gameIsOngoing &&
+      !options.winners.includes(options.playerChance)
+    ) {
+      setGameOptions({ hasThrownDice: true, });
       await rollDie(randomRollAmount());
     }
   };
@@ -129,15 +132,17 @@ const Dice = () => {
               <img id="dice-img" className={`${diceClass}`} src={img} alt="dice" />
           </Col>
 
-          {!options.hasThrownDice && (
-            <Col xs={6}>
-              <div>
-                <button className="roll-btn" onClick={roller}>
-                  Roll
-                </button>
-              </div>
-            </Col>
-          )}
+          {!options.hasThrownDice &&
+            options.gameIsOngoing &&
+            !options.winners.includes(options.playerChance) && (
+              <Col xs={6}>
+                <div>
+                  <button className="roll-btn" onClick={roller}>
+                    Roll
+                  </button>
+                </div>
+              </Col>
+            )}
         </Row>
       )}
     </React.Fragment>


### PR DESCRIPTION
## Description

This PR addresses the issue where players were able to roll the dice after reaching home. The changes ensure that once a player reaches home, they can no longer roll the dice. The logic was added to check if the player is a winner before allowing further dice rolls, preventing unnecessary actions.

## Related Issue(s)

Closes #<!-- issue number-->
## Checklist:

- [x] Read the [contributing docs](../CONTRIBUTING.md) (if this is your first contribution)
- [x] Verified this is not a duplicate of any [existing pull request](https://github.com/sivicstudio/starkludo/pulls)

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
