### PR TITLE
Fix Failing Tests related to the create_new_player()

### DIFF
--- a/onchain/src/tests/test_game.cairo
+++ b/onchain/src/tests/test_game.cairo
@@ -137,7 +137,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     #[should_panic(expected: ('USERNAME ALREADY TAKEN', 'ENTRYPOINT_FAILED',))]
     fn test_create_new_player_should_panic_if_username_already_exist() {
         let (_, game_action_system) = setup_world();
@@ -153,7 +152,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     #[should_panic(expected: ('USERNAME ALREADY CREATED', 'ENTRYPOINT_FAILED',))]
     fn test_create_new_player_should_fail_panic_username_already_created() {
         let (_, game_action_system) = setup_world();
@@ -169,7 +167,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_create_new_player_is_successful() {
         let (world, game_action_system) = setup_world();
         let caller = contract_address_const::<'ibs'>();

--- a/onchain/src/tests/test_game.cairo
+++ b/onchain/src/tests/test_game.cairo
@@ -145,10 +145,10 @@ mod tests {
         let caller_2 = contract_address_const::<'dreamer'>();
         let username = 'ibs';
 
-        testing::set_caller_address(caller_1);
+        testing::set_contract_address(caller_1);
         game_action_system.create_new_player(username, false);
 
-        testing::set_caller_address(caller_2);
+        testing::set_contract_address(caller_2);
         game_action_system.create_new_player(username, false);
     }
 
@@ -174,7 +174,7 @@ mod tests {
         let caller = contract_address_const::<'ibs'>();
         let username = 'ibs';
 
-        testing::set_caller_address(caller);
+        testing::set_contract_address(caller);
         game_action_system.create_new_player(username, false);
 
         let created_player: Player = world.read_model(username);

--- a/onchain/src/tests/test_game.cairo
+++ b/onchain/src/tests/test_game.cairo
@@ -159,12 +159,13 @@ mod tests {
         let (_, game_action_system) = setup_world();
         let caller = contract_address_const::<'ibs'>();
         let username = 'ibs';
+        let username1 = 'dreamer';
 
-        testing::set_caller_address(caller);
+        testing::set_contract_address(caller);
         // Player create username for the first time
         game_action_system.create_new_player(username, false);
-        // Player attempts to create username for the second time
-        game_action_system.create_new_player(username, false);
+        // Player attempts to create another username for the second time
+        game_action_system.create_new_player(username1, false);
     }
 
     #[test]


### PR DESCRIPTION
## Description

The failure was due to using set_caller_address, which only sets the address for the current contract. Since these tests involve calling an external contract (game_action_system), the appropriate function to set the address is set_contract_address.

## Related Issue(s)

Closes #185 
## Checklist:

- [x] Read the [contributing docs](../CONTRIBUTING.md) (if this is your first contribution)
- [x] Verified this is not a duplicate of any [existing pull request](https://github.com/sivicstudio/starkludo/pulls)

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
