### PR TITLE
Add Tests for create_bot_player() Function with Successful and Existing Player Scenarios

### DIFF
--- a/onchain/src/systems/game_actions.cairo
+++ b/onchain/src/systems/game_actions.cairo
@@ -313,7 +313,7 @@ pub mod GameActions {
                     player_address = contract_address_const::<'blue_bot'>();
                 },
                 PlayerColor::Red => {
-                    username = 'red_bot ';
+                    username = 'red_bot';
                     player_address = contract_address_const::<'red_bot'>();
                 }
             };

--- a/onchain/src/tests/test_game.cairo
+++ b/onchain/src/tests/test_game.cairo
@@ -14,7 +14,7 @@ mod tests {
     };
 
     // Models import
-    use starkludo::models::game::{Game, m_Game, GameCounter, m_GameCounter};
+    use starkludo::models::game::{Game, m_Game, GameCounter, m_GameCounter, PlayerColor};
     use starkludo::models::player::{
         Player, m_Player, AddressToUsername, UsernameToAddress, m_AddressToUsername,
         m_UsernameToAddress
@@ -183,6 +183,65 @@ mod tests {
 
         let address_to_username: AddressToUsername = world.read_model(caller);
         assert_eq!(address_to_username.username, username);
+    }
+
+    #[test]
+    fn test_create_bot_player_is_successful() {
+        let (_, game_action_system) = setup_world();
+
+        let blue_color = PlayerColor::Blue;
+        let green_color = PlayerColor::Green;
+        let red_color = PlayerColor::Red;
+        let yellow_color = PlayerColor::Yellow;
+
+        let created_blue_bot_player: Player = game_action_system.create_bot_player(blue_color);
+        let expected_blue_username = 'blue_bot';
+        let expected_blue_address = starknet::contract_address_const::<'blue_bot'>();
+        assert_eq!(created_blue_bot_player.username, expected_blue_username);
+        assert_eq!(created_blue_bot_player.owner, expected_blue_address);
+        assert_eq!(created_blue_bot_player.is_bot, true);
+
+        let created_green_bot_player: Player = game_action_system.create_bot_player(green_color);
+        let expected_green_username = 'green_bot';
+        let expected_green_address = starknet::contract_address_const::<'green_bot'>();
+        assert_eq!(created_green_bot_player.username, expected_green_username);
+        assert_eq!(created_green_bot_player.owner, expected_green_address);
+        assert_eq!(created_green_bot_player.is_bot, true);
+
+        let created_red_bot_player: Player = game_action_system.create_bot_player(red_color);
+        let expected_red_username = 'red_bot';
+        let expected_red_address = starknet::contract_address_const::<'red_bot'>();
+        assert_eq!(created_red_bot_player.username, expected_red_username);
+        assert_eq!(created_red_bot_player.owner, expected_red_address);
+        assert_eq!(created_red_bot_player.is_bot, true);
+
+        let created_yellow_bot_player: Player = game_action_system.create_bot_player(yellow_color);
+        let expected_yellow_username = 'yellow_bot';
+        let expected_yellow_address = starknet::contract_address_const::<'yellow_bot'>();
+        assert_eq!(created_yellow_bot_player.username, expected_yellow_username);
+        assert_eq!(created_yellow_bot_player.owner, expected_yellow_address);
+        assert_eq!(created_yellow_bot_player.is_bot, true);
+    }
+
+    #[test]
+    fn test_create_existing_bot_player() {
+        let (_, game_action_system) = setup_world();
+
+        let blue_color = PlayerColor::Blue;
+        let created_blue_bot_player: Player = game_action_system.create_bot_player(blue_color);
+
+        let expected_blue_username = 'blue_bot';
+        let expected_blue_address = starknet::contract_address_const::<'blue_bot'>();
+        assert_eq!(created_blue_bot_player.username, expected_blue_username);
+        assert_eq!(created_blue_bot_player.owner, expected_blue_address);
+        assert_eq!(created_blue_bot_player.is_bot, true);
+
+        let existing_blue_bot_player: Player = game_action_system.create_bot_player(blue_color);
+
+        assert_eq!(existing_blue_bot_player.username, expected_blue_username);
+        assert_eq!(existing_blue_bot_player.owner, expected_blue_address);
+        assert_eq!(existing_blue_bot_player.is_bot, true);
+        assert_eq!(created_blue_bot_player.owner, existing_blue_bot_player.owner);
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR adds test cases for the create_bot_player() function located in game_actions.cairo. The tests cover both successful bot creation scenarios and existing bot player scenarios to ensure the function works as expected in all cases.

## Related Issue(s)

Closes #189 
## Checklist:

- [x] Read the [contributing docs](../CONTRIBUTING.md) (if this is your first contribution)
- [x] Verified this is not a duplicate of any [existing pull request](https://github.com/sivicstudio/starkludo/pulls)

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
